### PR TITLE
Function CreateCustomerContractLinesFromServiceCommitments in table 8052 "Customer Subscription Contract" is internal

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Customer Contracts/Tables/CustomerSubscriptionContract.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Customer Contracts/Tables/CustomerSubscriptionContract.Table.al
@@ -2007,7 +2007,11 @@ table 8052 "Customer Subscription Contract"
         end;
     end;
 
-    internal procedure CreateCustomerContractLinesFromServiceCommitments(var TempServiceCommitment: Record "Subscription Line" temporary)
+    /// <summary>
+    /// This function will be used to creates batch customer subscription contract lines from subscription lines which are not already assigned to a customer subscription contract. 
+    /// </summary>
+    /// <param name="TempServiceCommitment">Temporary VAR Record "Subscription Line".</param>
+    procedure CreateCustomerContractLinesFromServiceCommitments(var TempServiceCommitment: Record "Subscription Line" temporary)
     var
         ServiceObject: Record "Subscription Header";
     begin


### PR DESCRIPTION
#### Summary
In order to use CreateCustomerContractLinesFromServiceCommitments to assign a batch of subscriptio lines to a customer subscription contract, this function needs to be global

#### Work Item(s) 
Fixes #
